### PR TITLE
Fix refund condition

### DIFF
--- a/extensions/OrderTags/Condition.php
+++ b/extensions/OrderTags/Condition.php
@@ -45,6 +45,7 @@ class Condition
             'billing_country'       =>  __( 'Страна оплаты', IN_WC_CRM ),
             'billing_city'          =>  __( 'Город оплаты', IN_WC_CRM ),
             'shipping_country'      =>  __( 'Страна доставки', IN_WC_CRM ),
+            'shipping_state'      =>  __( 'Регион доставки', IN_WC_CRM ),
             'shipping_city'         =>  __( 'Город доставки', IN_WC_CRM ),
             'order_total'           =>  __( 'Сумма заказа', IN_WC_CRM ),
             'order_items'           =>  __( 'Число единиц товаров в заказе', IN_WC_CRM ),
@@ -197,6 +198,10 @@ class Condition
             case 'shipping_country':  
                 $paramValue = $order->get_shipping_country();
             break;
+
+            case 'shipping_state':  
+                $paramValue = $order->get_shipping_state();
+            break;            
 
             case 'shipping_city':  
                 $paramValue = $order->get_shipping_city();

--- a/extensions/OrderTags/RuleManager.php
+++ b/extensions/OrderTags/RuleManager.php
@@ -247,7 +247,9 @@ class RuleManager
             // Выбираем все правила
             $ruleIds = get_posts( array( 
                 'post_type' => self::CPT,
-                'fields'    => 'ids'
+                'fields'    => 'ids',
+                'numberposts' => -1,
+                'post_status'=>'publish'
             ) );
             
             // Формируем кэш-массив правил


### PR DESCRIPTION
Исправлено: 
1. Имя переменной, содержит объект заказа при переборе предыдущих заказов. $order исправлено на $previous_order.
2. Выборка всех имеющихся в БД заказов с данным email, а не только предустановленного количества. (wc_get_orders(), как и get_posts(), имеет предустановленное количество, поэтому тоже требует аргумента 'numberposts' => -1.


Добавлено:
1. Условие для назначения меток заказов "Содержит строку". Потому что не разобралась, почему не работает регулярка для refunded. Да и поиск подстроки в строке - дело простое. Хватает функции mb_strpos().