### PR TITLE
HOTFIX: Проверка на WP_Error при возврате из API BoxBerry

### DIFF
--- a/extensions/Boxberry/Boxberry.php
+++ b/extensions/Boxberry/Boxberry.php
@@ -142,7 +142,12 @@ class Boxberry extends Base
 
             foreach ( $results as $order_id => $result )
             {
-                if ( isset( $result['body'] ) )
+                if ( is_wp_error( $result ) )
+                {
+                    $responseStr .= $result->get_error_message();
+                    continue;
+                }
+                elseif ( isset( $result['body'] ) )
                 {
                     $resultObj = json_decode( $result['body'] );
                 }


### PR DESCRIPTION
BoxBerry API мог возвращать ошибку классом WP_Error, что приводило к редкому сбою в классе BoxBerry.
Cделана проверка на класс WP_Error.